### PR TITLE
Revert "Use keychain by default."

### DIFF
--- a/macosx/AppDelegate.m
+++ b/macosx/AppDelegate.m
@@ -35,7 +35,6 @@ pinentry_cmd_handler_t pinentry_cmd_handler = mac_cmd_handler;
 
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
 	[[NSUserDefaults standardUserDefaults] addSuiteNamed:@"org.gpgtools.common"];
-	[[NSUserDefaults standardUserDefaults] registerDefaults:@{@"UseKeychain": @YES}];
 
 	if (pinentry_loop()) {
 		exit(1);


### PR DESCRIPTION
Because I don't want to save passphrase to keychain, every time I have to uncheck "Save in Keychain" after entering passphrase.
Sometimes I forgot to uncheck and have to remove stored passphrase from Keychain Access App.
This is very frustrating.

"Use keychain by default" make the users wanting not to save have to uncheck many times.
After reverting it, the users wanting to save have to check only once.

So I want to revert this.