### PR TITLE
macOS: Replace Deprecated NSEvent/NSString APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.lo
 *.o
+*.a
+*~
 .deps/
 .libs/
 /aclocal.m4
@@ -10,7 +12,9 @@
 /config.status
 /configure
 /Makefile.in
+/Makefile
 /VERSION
+/stamp-h1
 autom4te.cache/
 assuan/Makefile.in
 assuan/Makefile
@@ -38,7 +42,11 @@ qt/icons/Makefile
 qt4/Makefile.in
 qt4/Makefile
 qt5/Makefile.in
+qt5/Makefile
 qt5/icons/Makefile.in
+qt5/icons/Makefile
+qt/org.gnupg.pinentry-qt.desktop
+qt5/org.gnupg.pinentry-qt5.desktop
 tqt/Makefile.in
 tqt/Makefile
 secmem/Makefile.in
@@ -51,6 +59,12 @@ tty/Makefile
 /qt/pinentrydialog.moc
 /qt/qsecurelineedit.moc
 /m4/Makefile.in
+/m4/Makefile
 /emacs/Makefile.in
+/emacs/Makefile
 macosx/Makefile.in
 macosx/Makefile
+macosx/pinentry-mac
+macosx/pinentry-mac.app/
+macosx/*.nib/
+macosx/*.lproj/

--- a/macosx/AppDelegate.m
+++ b/macosx/AppDelegate.m
@@ -118,7 +118,7 @@ NSDictionary *parseUserData(pinentry_t pe) {
 			[descriptionTemplate replaceOccurrencesOfString:@"%NAME" withString:name options:0 range:NSMakeRange(0, descriptionTemplate.length)];
 			[descriptionTemplate replaceOccurrencesOfString:@"%KEYID" withString:keyID options:0 range:NSMakeRange(0, descriptionTemplate.length)];
 
-			NSString *newDescription = [descriptionTemplate stringByReplacingPercentEscapesUsingEncoding:NSUTF8StringEncoding];
+			NSString *newDescription = [descriptionTemplate stringByRemovingPercentEncoding];
 			if (newDescription) {
 				description = newDescription;
 			}

--- a/macosx/ShortcutHandlingFields.m
+++ b/macosx/ShortcutHandlingFields.m
@@ -27,7 +27,7 @@
 @implementation ShortcutHandlingTextField
 
 - (BOOL)performKeyEquivalent:(NSEvent *)event {
-    if (([event modifierFlags] & NSDeviceIndependentModifierFlagsMask) == NSCommandKeyMask) {
+    if (([event modifierFlags] & NSEventModifierFlagDeviceIndependentFlagsMask) == NSEventModifierFlagCommand) {
         // The command key is the ONLY modifier key being pressed.
 
 		NSString *eventChars = event.charactersIgnoringModifiers;
@@ -49,7 +49,7 @@
 @implementation ShortcutHandlingSecureTextField
 
 - (BOOL)performKeyEquivalent:(NSEvent *)event {
-    if ((event.modifierFlags & NSDeviceIndependentModifierFlagsMask) == NSCommandKeyMask) {
+    if ((event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask) == NSEventModifierFlagCommand) {
 		// The command key is the ONLY modifier key being pressed.
 
 		NSString *eventChars = event.charactersIgnoringModifiers;


### PR DESCRIPTION
> **Disclosure:** this work was done as AI-augmented software engineering. I reviewed all code and thought carefully about how to make this work well on macOS, but I was focused specifically on macOS and don't know this codebase end-to-end — please review accordingly.

This pull request updates some macOS-specific code to use modern, preferred APIs and constants, improving code compatibility and maintainability. The main changes are grouped below:

**API Modernization and Compatibility:**

* Replaced the deprecated `stringByReplacingPercentEscapesUsingEncoding:` with the modern `stringByRemovingPercentEncoding` for decoding percent-escaped strings in `AppDelegate.m`.
* Updated usage of modifier flag constants in `ShortcutHandlingFields.m` to use the newer `NSEventModifierFlagDeviceIndependentFlagsMask` and `NSEventModifierFlagCommand` instead of the older `NSDeviceIndependentModifierFlagsMask` and `NSCommandKeyMask`, ensuring better compatibility with recent macOS SDKs. [[1]](diffhunk://#diff-de591cc9a20258aae4f6739579b71117a4bda44852cf470ef11eb84870903033L30-R30) [[2]](diffhunk://#diff-de591cc9a20258aae4f6739579b71117a4bda44852cf470ef11eb84870903033L52-R52)

Deliberately left the `SecKeychainOpen`/`SecKeychainCopyDefault`/`SecKeychainItemDelete` deprecations in `KeychainSupport.m` alone — those underpin the custom `KeychainPath` preference and swapping them means a real redesign, not a drop-in fix, so it didn't belong in this cleanup pass.

## .gitignore
Noticed while building locally that `macosx/Makefile.am` builds in-tree (compiled nibs, lproj folders, the raw executable, the `.app` bundle) with zero `.gitignore` coverage, static libraries (`*.a`) had no pattern at all unlike `*.o`/`*.lo`, and a few subdirectories (top-level, `emacs/`, `m4/`, `qt5/`, `qt5/icons/`) only ignored their `Makefile.in` template, not the generated `Makefile` — likely added to the build after this file was last updated. Fixed all of that, plus generated `.desktop` files, `stamp-h1`, and editor/tool backup files (`*~`).

## Testing
Rebuilt via `autogen.sh`/`configure`/`make` matching the Homebrew formula's exact flags; confirmed both files compile with no warnings for these specific APIs (down from the original 4 warnings).